### PR TITLE
Remove google webmaster tag

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,6 @@
     <title>Barberscore</title>
     <meta name="description" content="Contest Registration and Scoring System for the Barbershop Harmony Society.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="google-site-verification" content="80NiU_mxeuoizuJM0zE2wtZ2hHg8d77swC28XzuCVTI">
     <meta name="google-site-verification" content="G69J1WZ-_FcAX7PBGVZpio8muSsWPoz_DjyacLiIKmo">
 
     {{content-for "head"}}


### PR DESCRIPTION
Remove the google webmaster tag associated with my account; this will allow you to become the Google webmaster directly.