### PR TITLE
Add spreadsheet-style cascade paste for appearance scores

### DIFF
--- a/app/components/appearance-panelists.js
+++ b/app/components/appearance-panelists.js
@@ -1,7 +1,17 @@
 import Component from '@ember/component';
-import { sort, filterBy } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
+
+const SCORE_FIELDS = 'input.big-num:not([disabled]):not([readonly])';
+
+// A spreadsheet paste arrives as tab/newline delimited cells.
+function pastedCells(event) {
+  const text = event?.clipboardData?.getData('text') ?? '';
+  return text
+    .split(/[\t\r\n]+/)
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
 
 export default Component.extend({
   store: service(),
@@ -10,6 +20,32 @@ export default Component.extend({
     this._super(...arguments);
     this.setPanelists();
   },
+  // Spread a pasted column/grid of scores across the score fields, table order.
+  cascadePaste: action(function (event) {
+    const startEl = event.target;
+    if (!startEl.classList?.contains('big-num')) return;
+
+    const cells = pastedCells(event);
+    if (cells.length < 2) return;
+
+    // Multi-cell text never belongs in a single field, whatever we do next.
+    event.preventDefault();
+
+    const table = startEl.closest('table');
+    const fields = table ? [...table.querySelectorAll(SCORE_FIELDS)] : [];
+    const start = fields.indexOf(startEl);
+
+    // Only fill when every cell is a number and the counts line up exactly.
+    if (start < 0 || fields.length - start !== cells.length) return;
+    if (!cells.every((v) => Number.isFinite(Number(v)))) return;
+
+    cells.forEach((value, i) => {
+      const el = fields[start + i];
+      el.value = value;
+      // Keeps each panelist-score autosave in the loop.
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }),
   setPanelists: function() {
     const that = this;
     this.get('model.round.panelists').then(function (panelists) {

--- a/app/templates/components/appearance-panelists.hbs
+++ b/app/templates/components/appearance-panelists.hbs
@@ -2,7 +2,7 @@
   Scores
 </h6>
  <div class='table-responsive'>
-  <table class='table table-hover table-sm'>
+  <table class='table table-hover table-sm' {{on "paste" this.cascadePaste}}>
     <thead class='thead-light'>
       <tr>
         <th>


### PR DESCRIPTION
## Summary
- Paste a column of numbers into appearance score fields and fill matching empty fields in one go
- Skips paste when values aren't numbers or the count doesn't match the target fields